### PR TITLE
Add require fluent/parser to support newer fluent

### DIFF
--- a/lib/fluent/plugin/parser_jsonish.rb
+++ b/lib/fluent/plugin/parser_jsonish.rb
@@ -1,3 +1,5 @@
+require 'fluent/parser'
+
 module Fluent
   class TextParser
     class StdFormatTimeParser < TimeParser


### PR DESCRIPTION
This change allows support for fluent 0.14.0 and above otherwise you receive an error as such:

```
2018-03-27 22:37:46 +0000 [error]: unexpected error error_class=NameError error="uninitialized constant Fluent::TextParser::JSONParser"
  2018-03-27 22:37:46 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/fluent-plugin-jsonish-1.0.2/lib/fluent/plugin/parser_jsonish.rb:35:in `<class:TextParser>'
```